### PR TITLE
Fix imports for system.common.get_pictures_dir

### DIFF
--- a/redlib/system/common.py
+++ b/redlib/system/common.py
@@ -1,5 +1,6 @@
 import sys
 import platform
+from os import mkdir
 from os.path import expanduser, join as joinpath, exists
 
 


### PR DESCRIPTION
If `~/Pictures` does not exist then the function tries to create it.
But it fails because `mkdir` was not imported.